### PR TITLE
feat: optional semantic recall (hybrid keyword + embedding retrieval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,39 @@ mycelium serve --transport http --port 8200 &
 > `127.0.0.1` for one machine, or to a private interface (Tailscale, LAN)
 > for trusted multi-machine. Don't expose it to the public internet.
 
+## Optional: semantic recall
+
+By default, recall is lexical (SQLite FTS5) — fast, zero-dependency, and it
+matches on keywords. If you also point mycelium at an embedding endpoint, recall
+becomes **hybrid**: it additionally finds memories by *meaning*, so a query like
+"how does the token refresh work" can surface a note about "OAuth credential
+renewal" even with no shared words.
+
+This is **off by default** and adds **no dependency** — set one config value to
+turn it on, leave it unset and nothing changes.
+
+```toml
+# ~/.mycelium/config.toml
+[semantic]
+embed_url = "http://localhost:11434/v1/embeddings"   # any OpenAI-compatible endpoint
+embed_model = "nomic-embed-text"
+```
+
+Works with anything that speaks the OpenAI `/v1/embeddings` API — **Ollama**
+(`ollama pull nomic-embed-text`), LM Studio, llama.cpp `--embedding`, or a cloud
+provider. Then embed your existing memories once:
+
+```bash
+mycelium backfill-vectors      # new memories are embedded automatically on save
+```
+
+Notes:
+- Graceful: if the endpoint is unreachable, recall silently falls back to lexical.
+- `numpy` is used for the similarity search only if it happens to be installed;
+  otherwise a pure-Python path is used. Not a required dependency.
+- Tunables live under `[semantic]` (see `config.example.toml`): `weight`,
+  `top_k`, `chunk_chars`, `timeout_seconds`.
+
 ## Backups
 
 Your data lives in `~/.mycelium/memory.db` (semantic) and

--- a/config.example.toml
+++ b/config.example.toml
@@ -44,3 +44,19 @@ ingest_interval_seconds = 0            # 0 = manual; >0 = run drain loop in back
 # Optional cleanup. Set to 0 to disable.
 max_rows = 0           # 0 = unlimited
 max_age_days = 0       # 0 = no age limit
+
+[semantic]
+# OPTIONAL semantic recall. Off by default — mycelium's core is pure SQLite+FTS5
+# with no extra dependency. Set embed_url to ANY OpenAI-compatible /v1/embeddings
+# endpoint to enable hybrid (keyword + meaning) recall. When unset, recall behaves
+# exactly as before and no embedding calls are made.
+#
+# Local options (recommended): Ollama -> "http://localhost:11434/v1/embeddings"
+#   (`ollama pull nomic-embed-text`), LM Studio, or llama.cpp --embedding.
+# After enabling, backfill existing memories once:  mycelium backfill-vectors
+embed_url = ""                         # e.g. "http://localhost:11434/v1/embeddings"
+embed_model = "nomic-embed-text"       # nomic-embed-text | embeddinggemma | bge-* | text-embedding-3-small ...
+weight = 10.0                          # how strongly cosine similarity drives ranking
+top_k = 15                             # semantic candidates merged into the recall pool
+chunk_chars = 1400                     # long memories are chunked + mean-pooled under this
+timeout_seconds = 5                    # per embed call; keeps recall/save responsive

--- a/mycelium/cli.py
+++ b/mycelium/cli.py
@@ -93,6 +93,21 @@ def _cmd_config(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_backfill_vectors(args: argparse.Namespace) -> int:
+    from . import server
+    server.set_config(_config.load(args.config))
+    try:
+        r = server.backfill_vectors(reembed=args.reembed)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        print("set [semantic] embed_url in your config first (see config.example.toml).",
+              file=sys.stderr)
+        return 1
+    print(f"embedded {r['embedded']}, failed {r['failed']}; "
+          f"{r['total']}/{r['memories']} memories have vectors")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(prog="mycelium", description="Mycelium memory MCP server")
     p.add_argument("--config", help="path to config.toml (overrides search paths)")
@@ -111,6 +126,14 @@ def main(argv: list[str] | None = None) -> int:
 
     cfg_cmd = sub.add_parser("config", help="print effective config")
     cfg_cmd.set_defaults(func=_cmd_config)
+
+    bv = sub.add_parser(
+        "backfill-vectors",
+        help="embed all memories for semantic recall (requires [semantic] embed_url)",
+    )
+    bv.add_argument("--reembed", action="store_true",
+                    help="re-embed even memories that already have a vector")
+    bv.set_defaults(func=_cmd_backfill_vectors)
 
     m = sub.add_parser("maintain", help="snapshot + cold-mark + orphan rescue (dry-run by default)")
     m.add_argument("--execute", action="store_true", help="apply the plan (default is dry-run)")

--- a/mycelium/config.py
+++ b/mycelium/config.py
@@ -42,6 +42,16 @@ DEFAULTS: dict[str, Any] = {
         "ingest_interval_seconds": 0,
         "retention": {"max_rows": 0, "max_age_days": 0},
     },
+    "semantic": {
+        # Optional semantic-recall arm. Disabled while embed_url is empty —
+        # recall stays pure-lexical (FTS5) and no embedding calls are made.
+        "embed_url": "",                # any OpenAI-compatible /v1/embeddings
+        "embed_model": "nomic-embed-text",
+        "weight": 10.0,                 # cosine multiplier in recall scoring
+        "top_k": 15,                    # semantic candidates merged into the pool
+        "chunk_chars": 1400,            # long-content chunk size before mean-pool
+        "timeout_seconds": 5,           # per embed call; keep recall/save snappy
+    },
 }
 
 
@@ -134,7 +144,12 @@ class Config:
     storage: dict
     memory: dict
     foundry: dict
+    semantic: dict
     source: str  # "defaults" | "<path-to-toml>"
+
+    @property
+    def semantic_enabled(self) -> bool:
+        return bool(self.semantic.get("embed_url"))
 
     @property
     def db_path(self) -> Path:
@@ -154,6 +169,7 @@ class Config:
             "storage": self.storage,
             "memory": self.memory,
             "foundry": self.foundry,
+            "semantic": self.semantic,
         }
 
 
@@ -165,6 +181,7 @@ def load(config_path: str | None = None) -> Config:
     cfg = {k: (dict(v) if isinstance(v, dict) else v) for k, v in DEFAULTS.items()}
     # deep-copy nested dicts
     cfg["foundry"]["retention"] = dict(DEFAULTS["foundry"]["retention"])
+    cfg["semantic"] = dict(DEFAULTS["semantic"])
 
     explicit = config_path or os.environ.get("MYCELIUM_CONFIG")
     found_path: Path | None = None
@@ -184,5 +201,6 @@ def load(config_path: str | None = None) -> Config:
         storage=cfg["storage"],
         memory=cfg["memory"],
         foundry=cfg["foundry"],
+        semantic=cfg["semantic"],
         source=str(found_path) if found_path else "defaults",
     )

--- a/mycelium/embeddings.py
+++ b/mycelium/embeddings.py
@@ -1,0 +1,121 @@
+"""Optional embedding client for semantic recall.
+
+Pure standard library — no third-party deps. Talks to any OpenAI-compatible
+``/v1/embeddings`` endpoint (Ollama, LM Studio, llama.cpp, OpenAI, ...). This
+module is only imported/used when ``[semantic] embed_url`` is configured;
+mycelium's core stays dependency-free and behaves exactly as before when it is
+unset.
+
+Cosine uses numpy *opportunistically* if it happens to be installed (faster on
+large corpora), but falls back to a pure-Python dot product — numpy is never
+required.
+"""
+from __future__ import annotations
+
+import json
+import math
+import struct
+import urllib.request
+
+# Asymmetric query/document prompts matter for some models and not others.
+# Keyed by case-insensitive substring of the model name; unknown -> no prefix.
+#   value = (document_prefix, query_prefix)
+_PREFIXES = {
+    "nomic": ("search_document: ", "search_query: "),
+    "embeddinggemma": ("title: none | text: ", "task: search result | query: "),
+    "gemma": ("title: none | text: ", "task: search result | query: "),
+    "e5": ("passage: ", "query: "),
+}
+
+
+def _prefixes(model: str) -> tuple[str, str]:
+    m = (model or "").lower()
+    for key, pair in _PREFIXES.items():
+        if key in m:
+            return pair
+    return ("", "")
+
+
+def _post(url: str, model: str, inputs: list[str], timeout: float) -> list[list[float]]:
+    body = json.dumps({"model": model, "input": inputs}).encode()
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = json.loads(resp.read())["data"]
+    # Preserve input order regardless of how the server returns them.
+    return [d["embedding"] for d in sorted(data, key=lambda d: d.get("index", 0))]
+
+
+def _chunks(text: str, n: int) -> list[str]:
+    text = (text or "").strip()
+    return [text[i : i + n] for i in range(0, len(text), n)] or [""]
+
+
+def _normalize(v: list[float]) -> list[float]:
+    norm = math.sqrt(sum(x * x for x in v)) or 1.0
+    return [x / norm for x in v]
+
+
+def _mean(vecs: list[list[float]]) -> list[float]:
+    dim = len(vecs[0])
+    out = [0.0] * dim
+    for v in vecs:
+        for i, x in enumerate(v):
+            out[i] += x
+    return [x / len(vecs) for x in out]
+
+
+def embed_document(text, *, url, model, chunk_chars=1400, timeout=5):
+    """One L2-normalized vector for a memory. Long content is chunked and the
+    per-chunk vectors are mean-pooled (keeps inputs under model context limits)."""
+    doc_prefix, _ = _prefixes(model)
+    chunks = _chunks(text, chunk_chars)
+    vecs = [_normalize(v) for v in _post(url, model, [doc_prefix + c for c in chunks], timeout)]
+    return _normalize(_mean(vecs)) if len(vecs) > 1 else vecs[0]
+
+
+def embed_query(text, *, url, model, timeout=5):
+    """One L2-normalized query vector."""
+    _, query_prefix = _prefixes(model)
+    return _normalize(_post(url, model, [query_prefix + text], timeout)[0])
+
+
+def to_blob(vec: list[float]) -> bytes:
+    """Serialize a vector to a compact little-endian float32 BLOB."""
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def from_blob(blob: bytes) -> list[float]:
+    return list(struct.unpack(f"<{len(blob) // 4}f", blob))
+
+
+def cosine_sims(qvec, rows) -> dict:
+    """{memory_id: cosine} for rows of (memory_id, blob).
+
+    Stored vectors and ``qvec`` are L2-normalized, so a dot product is the
+    cosine. Uses numpy if available (and the buffer is uniform), else pure
+    Python — numpy is an optional speedup, not a requirement.
+    """
+    rows = list(rows)
+    if not rows:
+        return {}
+    try:
+        import numpy as np
+
+        mat = np.frombuffer(b"".join(r[1] for r in rows), dtype="float32").reshape(
+            len(rows), -1
+        )
+        sims = mat @ np.asarray(qvec, dtype="float32")
+        return {rows[i][0]: float(sims[i]) for i in range(len(rows))}
+    except Exception:
+        return {mid: sum(a * b for a, b in zip(qvec, from_blob(blob))) for mid, blob in rows}
+
+
+def healthy(url, model, timeout=5) -> bool:
+    """True if the embedding endpoint answers — used for graceful fallback."""
+    try:
+        _post(url, model, ["healthcheck"], timeout)
+        return True
+    except Exception:
+        return False

--- a/mycelium/server.py
+++ b/mycelium/server.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from mcp.server.fastmcp import FastMCP
 
 from . import config as _config
+from . import embeddings as _embed
 from . import maintain as _maintain
 from .foundry import publish as foundry_publish
 from .foundry import ingest as foundry_ingest
@@ -170,6 +171,14 @@ def _init_schema(conn: sqlite3.Connection) -> None:
             computed_at TEXT NOT NULL,
             UNIQUE(week_start)
         );
+
+        CREATE TABLE IF NOT EXISTS memory_vectors (
+            memory_id INTEGER PRIMARY KEY REFERENCES memories(id) ON DELETE CASCADE,
+            dim       INTEGER NOT NULL,
+            model     TEXT    NOT NULL,
+            vec       BLOB    NOT NULL,
+            updated   TEXT    NOT NULL
+        );
     """)
     conn.commit()
 
@@ -177,6 +186,74 @@ def _init_schema(conn: sqlite3.Connection) -> None:
 # ----- helpers -----
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+# ----- semantic recall (optional; active only when [semantic] embed_url set) -----
+def _semantic_sims(conn: sqlite3.Connection, qvec) -> dict:
+    """{memory_id: cosine} over stored vectors. {} on any failure so recall
+    degrades cleanly to pure lexical."""
+    try:
+        rows = conn.execute("SELECT memory_id, vec FROM memory_vectors").fetchall()
+        return _embed.cosine_sims(qvec, [(r["memory_id"], r["vec"]) for r in rows])
+    except Exception:
+        return {}
+
+
+def _embed_memory(conn: sqlite3.Connection, memory_id: int, content: str) -> bool:
+    """Best-effort: embed one memory and upsert its vector. Never raises."""
+    sem = _cfg().semantic
+    if not sem.get("embed_url"):
+        return False
+    try:
+        v = _embed.embed_document(
+            content or "",
+            url=sem["embed_url"],
+            model=sem["embed_model"],
+            chunk_chars=int(sem["chunk_chars"]),
+            timeout=float(sem["timeout_seconds"]),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO memory_vectors (memory_id, dim, model, vec, updated) "
+            "VALUES (?,?,?,?,?)",
+            (memory_id, len(v), sem["embed_model"], _embed.to_blob(v), _now()),
+        )
+        return True
+    except Exception:
+        return False  # memory still saved; backfill can fill the vector later
+
+
+def backfill_vectors(reembed: bool = False) -> dict:
+    """Embed all memories into memory_vectors. Idempotent + resumable: skips
+    memories already embedded for the current model unless reembed=True."""
+    sem = _cfg().semantic
+    if not sem.get("embed_url"):
+        raise RuntimeError("[semantic] embed_url is not configured")
+    conn = get_db()
+    rows = conn.execute("SELECT id, content FROM memories").fetchall()
+    done: set[int] = set()
+    if not reembed:
+        done = {
+            r[0]
+            for r in conn.execute(
+                "SELECT memory_id FROM memory_vectors WHERE model=?", (sem["embed_model"],)
+            )
+        }
+    ok = fail = 0
+    for r in rows:
+        if r["id"] in done:
+            continue
+        if _embed_memory(conn, r["id"], r["content"]):
+            ok += 1
+        else:
+            fail += 1
+        if (ok + fail) % 100 == 0:
+            conn.commit()
+    conn.commit()
+    total = conn.execute(
+        "SELECT COUNT(*) FROM memory_vectors WHERE model=?", (sem["embed_model"],)
+    ).fetchone()[0]
+    conn.close()
+    return {"embedded": ok, "failed": fail, "total": total, "memories": len(rows)}
 
 
 def _decay_strength(strength: float, last_activated: str) -> float:
@@ -560,6 +637,12 @@ def save(
 
     conn.commit()
 
+    # Embed-on-save (optional, best-effort) so new memories are immediately
+    # reachable by semantic recall. Never blocks meaningfully or fails the save.
+    if _cfg().semantic.get("embed_url"):
+        if _embed_memory(conn, new_id, content):
+            conn.commit()
+
     lines = [f"Saved #{new_id}"]
     if project:
         lines[0] += f" ({project})"
@@ -655,6 +738,35 @@ def recall(query: str, project: str = "", limit: int = 5, agent: str = "") -> st
         ).fetchall()
         results = [dict(r) for r in results]
 
+    # Semantic arm (optional). Merges the top semantically-similar memories into
+    # the candidate pool so meaning-based queries reach memories that share no
+    # keywords. `sims` (id -> cosine) is reused below as a primary score term.
+    # Any failure (endpoint down, etc.) leaves sims empty -> pure lexical.
+    sem = _cfg().semantic
+    sims: dict = {}
+    if sem.get("embed_url"):
+        try:
+            qvec = _embed.embed_query(
+                query, url=sem["embed_url"], model=sem["embed_model"],
+                timeout=float(sem["timeout_seconds"]),
+            )
+            sims = _semantic_sims(conn, qvec)
+        except Exception:
+            sims = {}
+    if sims:
+        have = {r["id"] for r in results}
+        for mid, _cos in sorted(sims.items(), key=lambda kv: -kv[1])[: int(sem["top_k"])]:
+            if mid in have:
+                continue
+            row = conn.execute(
+                "SELECT id, content, project, tier, access_count, created, last_accessed "
+                "FROM memories WHERE id=?",
+                (mid,),
+            ).fetchone()
+            if row:
+                results.append(dict(row))
+                have.add(mid)
+
     if not results:
         conn.close()
         return "No memories found."
@@ -687,7 +799,10 @@ def recall(query: str, project: str = "", limit: int = 5, agent: str = "") -> st
                 recency_boost = 0.3 * math.exp(-days_old / 3.0)
             except (ValueError, TypeError):
                 pass
-        return coverage + access_boost + recency_boost
+        # Semantic similarity as a primary ranking signal (semantic-led). 0 when
+        # disabled or the memory has no vector, so lexical behavior is unchanged.
+        semantic_boost = float(sem["weight"]) * sims.get(memory["id"], 0.0) if sims else 0.0
+        return coverage + access_boost + recency_boost + semantic_boost
 
     pool: dict[int, tuple[dict, float, str]] = {}
     for r in results:

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -1,0 +1,131 @@
+"""Semantic recall tests — no live model required.
+
+A tiny in-process HTTP stub stands in for an OpenAI-compatible /v1/embeddings
+endpoint, returning deterministic vectors keyed on topic words so we can assert
+meaning-based behavior (e.g. "marine" bridging to an "ocean" memory that shares
+no keywords).
+"""
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from mycelium import config as _config
+from mycelium import embeddings as E
+from mycelium import server as S
+
+
+def _vec_for(text: str):
+    t = text.lower()
+    if any(k in t for k in ("ocean", "sea", "marine", "water")):
+        return [1.0, 0.0, 0.0]
+    if any(k in t for k in ("mountain", "alpine", "rock", "peak")):
+        return [0.0, 1.0, 0.0]
+    return [0.0, 0.0, 1.0]
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(n) or b"{}")
+        data = [{"index": i, "embedding": _vec_for(t)}
+                for i, t in enumerate(body.get("input", []))]
+        out = json.dumps({"data": data}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out)))
+        self.end_headers()
+        self.wfile.write(out)
+
+    def log_message(self, *a):  # silence
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_state():
+    # The server tracks co-accessed memories in a process-wide contextvar. These
+    # tests swap DBs in-process (which production never does), so reset it between
+    # tests to avoid bridging IDs from one tmp DB into another.
+    S._session_accessed.set(None)
+    yield
+
+
+@pytest.fixture
+def stub():
+    srv = HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}/v1/embeddings"
+    srv.shutdown()
+
+
+# ---- unit (no server) ----
+def test_blob_roundtrip():
+    v = [0.1, -0.2, 0.3, 0.0]
+    assert E.from_blob(E.to_blob(v)) == pytest.approx(v, abs=1e-6)
+
+
+def test_cosine_sims_pure_python():
+    q = E._normalize([1.0, 0.0])
+    rows = [(1, E.to_blob(E._normalize([1.0, 0.0]))),
+            (2, E.to_blob(E._normalize([0.0, 1.0])))]
+    sims = E.cosine_sims(q, rows)
+    assert sims[1] == pytest.approx(1.0, abs=1e-5)
+    assert sims[1] > sims[2]
+
+
+def test_prefixes_dispatch():
+    assert E._prefixes("nomic-embed-text")[1].startswith("search_query")
+    assert E._prefixes("embeddinggemma")[0].startswith("title:")
+    assert E._prefixes("text-embedding-3-small") == ("", "")
+
+
+# ---- config ----
+def test_semantic_off_by_default():
+    cfg = _config.load()
+    assert cfg.semantic["embed_url"] == ""
+    assert cfg.semantic_enabled is False
+
+
+def test_semantic_env_override(monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SEMANTIC_EMBED_URL", "http://x/v1/embeddings")
+    monkeypatch.setenv("MYCELIUM_SEMANTIC_WEIGHT", "7.5")
+    cfg = _config.load()
+    assert cfg.semantic_enabled is True
+    assert cfg.semantic["weight"] == 7.5
+
+
+# ---- embed against stub ----
+def test_embed_query_and_document(stub):
+    qv = E.embed_query("marine life", url=stub, model="test")
+    dv = E.embed_document("deep blue ocean", url=stub, model="test")
+    assert len(qv) == 3 and len(dv) == 3
+    assert E.cosine_sims(qv, [(1, E.to_blob(dv))])[1] == pytest.approx(1.0, abs=1e-5)
+
+
+# ---- end-to-end recall fusion ----
+def test_recall_semantic_bridges_vocabulary(tmp_path, stub, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_STORAGE_DB_PATH", str(tmp_path / "m.db"))
+    monkeypatch.setenv("MYCELIUM_SEMANTIC_EMBED_URL", stub)
+    monkeypatch.setenv("MYCELIUM_SEMANTIC_EMBED_MODEL", "test")
+    S.set_config(_config.load())
+
+    S.save("deep blue ocean trench biology", force=True)
+    S.save("tall alpine mountain ridge", force=True)
+
+    # "marine" shares NO keyword with the ocean memory — only the semantic arm
+    # can bridge it. Pure FTS would return nothing for this query.
+    out = S.recall("marine ecosystems", limit=5)
+    assert "ocean trench" in out, out
+    if "alpine mountain" in out:
+        assert out.index("ocean") < out.index("alpine")
+
+
+def test_recall_lexical_unchanged_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_STORAGE_DB_PATH", str(tmp_path / "m.db"))
+    monkeypatch.delenv("MYCELIUM_SEMANTIC_EMBED_URL", raising=False)
+    S.set_config(_config.load())
+    assert S._cfg().semantic_enabled is False
+    S.save("postgres connection pooling notes", force=True)
+    # keyword hit still works; no embedding endpoint is contacted
+    assert "postgres" in S.recall("postgres", limit=5)


### PR DESCRIPTION
## Optional semantic recall (hybrid retrieval)

Recall today is lexical (SQLite FTS5) — keyword matching. This adds an **opt-in**
semantic arm so recall can also find memories by *meaning*: a query like "how does
the token refresh work" can surface a note about "OAuth credential renewal" even
with no shared words.

### Design
- **Off by default, zero new dependency.** Inactive until `[semantic] embed_url`
  is set; unset = today's pure-FTS behavior, unchanged.
- **Bring your own endpoint.** Any OpenAI-compatible `/v1/embeddings` — Ollama
  (`nomic-embed-text`), LM Studio, llama.cpp `--embedding`, or a cloud provider.
- **Pure stdlib.** `numpy` is used for the similarity search *only if installed*;
  otherwise a pure-Python path runs. Not a required dependency.
- **Graceful.** Any embed failure (endpoint down, etc.) falls back to lexical.
- **Semantic-led fusion.** Top-`k` semantic candidates are merged into the recall
  pool and cosine similarity is added as a primary ranking term.

### What's included
- `mycelium/embeddings.py` — stdlib embedding client (model-aware query/doc
  prefixes, long-content chunk + mean-pool, float32 BLOB ser/deser, optional-numpy
  cosine).
- `server.py` — `memory_vectors` table, semantic candidate merge + scoring in
  `recall()`, best-effort embed-on-save in `save()` (short timeout, never blocks).
- `config.py` + `config.example.toml` — new `[semantic]` section
  (`embed_url`, `embed_model`, `weight`, `top_k`, `chunk_chars`, `timeout_seconds`),
  env-overridable via `MYCELIUM_SEMANTIC_*`.
- `cli.py` — `mycelium backfill-vectors` (idempotent/resumable) to embed existing
  memories.
- `tests/test_semantic.py` — unit + config + end-to-end recall fusion against an
  in-process stub endpoint (no live model needed in CI).

### Validation
- Full suite green (8/8); off-path confirmed unchanged with no `embed_url`.
- End-to-end against a real EmbeddingGemma endpoint: a no-keyword query
  ("undersea aquatic wildlife") correctly surfaced an "ocean/coral" memory far
  above an unrelated one.

### Usage
```toml
[semantic]
embed_url = "http://localhost:11434/v1/embeddings"
embed_model = "nomic-embed-text"
```
```bash
mycelium backfill-vectors
```
