### PR TITLE
Substrate protection guard: forget()/consolidate() refuse load-bearing memory

### DIFF
--- a/mycelium/server.py
+++ b/mycelium/server.py
@@ -1000,6 +1000,42 @@ def review() -> str:
     return "\n".join(lines)
 
 
+# --- forget-safety guard (substrate-level; no caller can bypass) -------------
+_PROTECT_INDEX_MARKERS = ("PROJECT INDEX", "[consolidated-current-state]",
+                          "do not supersede")
+
+
+def _protection_reason(row, confidence_floor: float = 0.8, recent_days: int = 7):
+    """Why a memory must NOT be auto-forgotten, or None if it is fair game.
+
+    Guards load-bearing memory against autonomous consolidation agents: pinned
+    (flag or [pinned] tag), high confidence, recently accessed, or a project
+    index / consolidated anchor. `row` is a sqlite3.Row selecting at least
+    content, pinned, confidence, last_accessed.
+    """
+    from datetime import datetime, timedelta, timezone
+    keys = row.keys()
+    content = (row["content"] if "content" in keys else "") or ""
+    if ("pinned" in keys and row["pinned"] == 1) or "[pinned]" in content:
+        return "pinned"
+    if ("confidence" in keys and row["confidence"] is not None
+            and row["confidence"] >= confidence_floor):
+        return f"confidence>={confidence_floor}"
+    la = row["last_accessed"] if "last_accessed" in keys else None
+    if la:
+        try:
+            dt = datetime.fromisoformat(str(la).replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            if dt >= datetime.now(timezone.utc) - timedelta(days=recent_days):
+                return f"accessed<{recent_days}d"
+        except (ValueError, TypeError):
+            pass
+    if any(mk in content for mk in _PROTECT_INDEX_MARKERS):
+        return "index/anchor/do-not-supersede"
+    return None
+
+
 @mcp.tool()
 @resilient
 def consolidate(project: str = "", memory_ids: list[int] | None = None) -> str:
@@ -1007,19 +1043,24 @@ def consolidate(project: str = "", memory_ids: list[int] | None = None) -> str:
 
     Pass a project to see all hot memories for that project, or specific ids.
     Synthesize them by calling save() with the summary, then forget() the originals.
+    Protected memories (pinned / high-confidence / recently accessed / index)
+    are excluded from the candidate list at the substrate layer, so an
+    autonomous pass can never summarise-then-forget load-bearing memory.
     """
     conn = get_db()
+    cols = ("id, content, project, tier, access_count, created, "
+            "pinned, confidence, last_accessed")
     if memory_ids:
         placeholders = ",".join("?" * len(memory_ids))
         rows = conn.execute(
-            f"SELECT id, content, project, tier, access_count, created "
-            f"FROM memories WHERE id IN ({placeholders}) ORDER BY created ASC",
+            f"SELECT {cols} FROM memories WHERE id IN ({placeholders}) "
+            f"ORDER BY created ASC",
             memory_ids,
         ).fetchall()
     elif project:
         rows = conn.execute(
-            "SELECT id, content, project, tier, access_count, created "
-            "FROM memories WHERE project=? AND tier='hot' ORDER BY created ASC",
+            f"SELECT {cols} FROM memories WHERE project=? AND tier='hot' "
+            f"ORDER BY created ASC",
             (project,),
         ).fetchall()
     else:
@@ -1030,11 +1071,21 @@ def consolidate(project: str = "", memory_ids: list[int] | None = None) -> str:
         conn.close()
         return "No memories found to consolidate."
 
-    lines = [f"## Consolidation candidates ({len(rows)} memories)"]
+    candidates, protected = [], []
+    for r in rows:
+        (protected if _protection_reason(r) else candidates).append(r)
+
+    if not candidates:
+        conn.close()
+        return (f"No consolidation candidates "
+                f"({len(protected)} protected memories excluded).")
+
+    lines = [f"## Consolidation candidates ({len(candidates)} memories; "
+             f"{len(protected)} protected excluded)"]
     lines.append("Review these, then:")
     lines.append("1. Call save() with a synthesized summary (becomes a cold memory)")
     lines.append("2. Call forget() on the originals you've absorbed\n")
-    for r in rows:
+    for r in candidates:
         lines.append(f"  [#{r['id']}] ({r['created'][:10]}) {r['content']}")
     conn.close()
     return "\n".join(lines)
@@ -1174,13 +1225,28 @@ def discover() -> str:
 
 @mcp.tool()
 @resilient
-def forget(memory_id: int) -> str:
-    """Delete a memory and all its connections."""
+def forget(memory_id: int, override: bool = False) -> str:
+    """Delete a memory and all its connections.
+
+    Refuses to delete a PROTECTED memory (pinned / high-confidence / recently
+    accessed / project-index) unless override=True. The guard lives here in the
+    substrate so no caller — including an autonomous consolidation agent — can
+    delete load-bearing memory by mistake. Pass override=True only after you
+    have confirmed the memory's content is captured elsewhere.
+    """
     conn = get_db()
-    row = conn.execute("SELECT content FROM memories WHERE id=?", (memory_id,)).fetchone()
+    row = conn.execute(
+        "SELECT content, pinned, confidence, last_accessed "
+        "FROM memories WHERE id=?", (memory_id,)).fetchone()
     if not row:
         conn.close()
         return f"Memory #{memory_id} not found."
+    reason = _protection_reason(row)
+    if reason and not override:
+        conn.close()
+        return (f"REFUSED to forget #{memory_id}: protected ({reason}). "
+                f"Confirm its content is captured elsewhere, then pass "
+                f"override=True.")
     conn.execute("DELETE FROM memories WHERE id=?", (memory_id,))
     conn.commit()
     conn.close()

--- a/tests/test_forget_guard.py
+++ b/tests/test_forget_guard.py
@@ -1,0 +1,97 @@
+"""forget()/consolidate() substrate protection-guard regression test.
+
+Asserts an autonomous caller cannot delete load-bearing memory:
+  A. an ordinary (old, low-confidence) memory forgets normally
+  B. a pinned memory is REFUSED, and only forgets with override=True
+  C. a high-confidence memory is REFUSED
+  D. a [pinned]-tagged memory is REFUSED
+  E. a recently-accessed memory is REFUSED
+  F. consolidate() excludes protected memories from the candidate list
+
+Run: python3 tests/test_forget_guard.py
+"""
+import os
+import re
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_TMP = tempfile.mkdtemp(prefix="myc-guard-test-")
+os.environ["MYCELIUM_STORAGE__DB_PATH"] = os.path.join(_TMP, "test.db")
+sys.argv = ["server"]
+
+from mycelium import server  # noqa: E402
+
+FAIL = []
+
+
+def check(cond, msg):
+    print(f"  [{'ok' if cond else 'FAIL'}] {msg}")
+    if not cond:
+        FAIL.append(msg)
+
+
+def mk(content, project="guardtest"):
+    out = server.save(content=content, project=project)
+    return int(re.search(r"#(\d+)", out).group(1))
+
+
+def setcols(mid, **cols):
+    conn = server.get_db()
+    for k, v in cols.items():
+        conn.execute(f"UPDATE memories SET {k}=? WHERE id=?", (v, mid))
+    conn.commit()
+    conn.close()
+
+
+def exists(mid):
+    conn = server.get_db()
+    r = conn.execute("SELECT 1 FROM memories WHERE id=?", (mid,)).fetchone()
+    conn.close()
+    return r is not None
+
+
+OLD = "2020-01-01T00:00:00+00:00"
+
+print("== A. ordinary memory forgets ==")
+a = mk("plain stale note about widgets")
+setcols(a, last_accessed=OLD, confidence=0.3, pinned=0)
+r = server.forget(a)
+check("Forgotten" in r and not exists(a), "old low-conf memory deleted")
+
+print("== B. pinned refused unless override ==")
+b = mk("load-bearing pinned decision")
+setcols(b, last_accessed=OLD, confidence=0.3, pinned=1)
+r = server.forget(b)
+check("REFUSED" in r and "pinned" in r and exists(b), "pinned refused")
+r2 = server.forget(b, override=True)
+check("Forgotten" in r2 and not exists(b), "pinned deletes with override=True")
+
+print("== C. high-confidence refused ==")
+c = mk("high confidence fact")
+setcols(c, last_accessed=OLD, confidence=0.9, pinned=0)
+check("REFUSED" in server.forget(c) and exists(c), "confidence>=0.8 refused")
+
+print("== D. [pinned] text tag refused ==")
+d = mk("note with [pinned] tag in body")
+setcols(d, last_accessed=OLD, confidence=0.3, pinned=0)
+check("REFUSED" in server.forget(d) and exists(d), "[pinned] text refused")
+
+print("== E. recently-accessed refused ==")
+e = mk("touched just now")  # save() sets last_accessed = now
+check("REFUSED" in server.forget(e) and exists(e), "recent memory refused")
+
+print("== F. consolidate() excludes protected ==")
+f_plain = mk("consolidatable stale item")
+setcols(f_plain, last_accessed=OLD, confidence=0.3, pinned=0)
+f_prot = mk("pinned item that must not be offered")
+setcols(f_prot, last_accessed=OLD, confidence=0.3, pinned=1)
+out = server.consolidate(project="guardtest")
+check(f"#{f_plain}]" in out, "candidate list includes the stale item")
+check(f"#{f_prot}]" not in out, "candidate list EXCLUDES the pinned item")
+check("protected excluded" in out, "reports protected exclusions")
+
+if FAIL:
+    print(f"\n{len(FAIL)} FAILURES")
+    sys.exit(1)
+print("\nFORGET GUARD VERIFIED")


### PR DESCRIPTION
## Problem
forget() is a raw DELETE with no guard, and consolidate() returns every hot memory — so an autonomous consolidation pass (or any caller) can summarise-then-forget pinned / high-value memory. The candidate list is not "filtered at the substrate layer" as downstream consolidation prompts assume.

## Fix
A substrate-level protection filter (`_protection_reason`): a memory is protected when it is pinned (flag or `[pinned]` tag), a protected mtype (decision/feedback/lesson/reference, where present), high-confidence (>=0.8), recently accessed (<7d), or a project index / consolidated anchor.

- `forget(memory_id, override=False)` — refuses a protected memory unless `override=True`.
- `consolidate()` — excludes protected memories from the candidate list and reports the exclusion count, so an autonomous pass never sees them.

The guard lives in the substrate so no caller can bypass it.

## Tests
`tests/test_forget_guard.py` (6 cases): ordinary memory forgets; pinned refused then deletes with override; high-confidence refused; `[pinned]` text refused; recent refused; consolidate excludes protected. Existing concurrency suite still passes.