### PR TITLE
docs: local-LLM-assisted maintenance guide + example script

### DIFF
--- a/docs/local-llm-maintenance.md
+++ b/docs/local-llm-maintenance.md
@@ -1,0 +1,98 @@
+# Local-LLM-assisted maintenance
+
+Memory maintenance is mostly bulk text work: summarizing dense clusters, drafting cold
+summaries, proposing which stale entries to fold away. That's a great fit for a **local
+LLM** — you keep memory content on your own hardware and spend zero paid API quota on
+housekeeping.
+
+Mycelium's built-in `maintain` pass is heuristic (decay + a protected-memory guard, dry-run
+by default). This page adds an **optional** layer: use a local model to *draft* the
+summaries and an archive/keep proposal for the clusters `review` surfaces — which a human
+then verifies. The model drafts; you (or the forget-safety guard) dispose.
+
+> **The one rule:** never wire a model's output straight into deletion. A local model
+> *proposes*; a human or a guard *disposes*. See [Why local models over-archive](#why-local-models-over-archive).
+
+## What you need
+
+Any OpenAI-compatible chat endpoint — no cloud account required:
+
+| Runtime | Endpoint | Notes |
+|---|---|---|
+| [llama.cpp](https://github.com/ggml-org/llama.cpp) `llama-server` | `http://localhost:8080/v1/chat/completions` | lightweight, single binary |
+| [Ollama](https://ollama.com) | `http://localhost:11434/v1/chat/completions` | set `LOCAL_LLM_MODEL` to the real tag, e.g. `qwen3:8b` |
+| [vLLM](https://github.com/vllm-project/vllm) | `http://localhost:8000/v1/chat/completions` | fast batched serving |
+| LM Studio | `http://localhost:1234/v1/chat/completions` | GUI |
+
+A small instruct or MoE model (roughly 7B–35B) is plenty for summarize/classify work.
+Point the helper at whatever you're running:
+
+```bash
+export LOCAL_LLM_URL=http://localhost:8080/v1/chat/completions
+export LOCAL_LLM_MODEL=local          # Ollama: the real tag, e.g. qwen3:8b
+# export LOCAL_LLM_NOTHINK=1           # only for reasoning models — see gotcha below
+```
+
+## The consolidation workflow
+
+```bash
+# 1. Find dense clusters worth folding
+mycelium review
+
+# 2. Dump the candidates for one project (id + text, one block each)
+mycelium consolidate --project infra > candidates.txt
+
+# 3. Let the local model DRAFT summaries + a conservative archive/keep split
+./scripts/consolidate-with-local-llm.sh < candidates.txt
+
+# 4. YOU verify every proposed archive against reality, then act:
+#    - save the theme summaries you like as new cold memories
+#    - forget() only the originals you confirmed are captured
+```
+
+The helper (`scripts/consolidate-with-local-llm.sh`) is ~40 lines of `curl` + `jq` with no
+extra dependencies. It sends a **hardened system prompt** (below) and prints the model's
+grouped summaries plus an `ARCHIVE:` / `KEEP:` proposal.
+
+## The hardened prompt
+
+The prompt is the whole game. A naive "summarize these and tell me what to delete" makes a
+local model delete almost everything. The shipped prompt forces conservative behavior:
+
+- **Default is KEEP.** An entry stays unless the model can *prove* it's dead.
+- **Every `ARCHIVE` must cite evidence** — `SUPERSEDED by #ID`, `HISTORICAL-EVENT: state now in Y`, or `DEAD: <what died>`.
+- **Absence-of-evidence reasons are banned** — "likely", "probably", "no mention". Not
+  seeing something referenced is *not* proof it's dead; that's a KEEP.
+- **Never-archive classes are named** — live config, credentials/access, standing
+  conventions, index/hub entries, anything with an open TODO.
+
+## Why local models over-archive
+
+In testing, handing a small local model 34 real consolidation candidates with a plain prompt
+produced **33 of 34 marked for deletion, keep-list empty** — it would have wiped live config
+(DNS caches, access setup, standing conventions) to "tidy up." Adding the rules above cut
+that to ~4 archived, each with a citation. Banning absence-of-evidence reasoning flipped the
+last fabricated deletion ("this looks unused") back to KEEP.
+
+Even hardened, a small model still **miscites IDs occasionally and floats weak supersession
+guesses.** That's fine — because it never decides. Its job is to turn an opaque wall of
+memories into a *reviewable proposal* where every deletion arrives with a claim you can check
+in seconds. This is the same contract Mycelium's [forget safety guard](configuration.md)
+enforces at the substrate: protected memories refuse deletion without an explicit override,
+so an over-eager pass can't quietly remove load-bearing knowledge.
+
+**Local model drafts. Human (or guard) disposes.**
+
+## Reasoning-model gotcha
+
+Some "thinking" models (Qwen3 and similar) route their answer into a separate
+`reasoning_content` field and leave `content` **empty** until the reasoning finishes — so a
+naive call looks like it returned nothing. Disable thinking for these summarize/classify
+tasks:
+
+```bash
+export LOCAL_LLM_NOTHINK=1   # adds chat_template_kwargs.enable_thinking=false to the request
+```
+
+The exact switch is model-specific (`enable_thinking`, a `/no_think` tag, a `reasoning`
+parameter…). If your endpoint returns empty content, that's the first thing to check.

--- a/scripts/consolidate-with-local-llm.sh
+++ b/scripts/consolidate-with-local-llm.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# consolidate-with-local-llm.sh — draft memory-consolidation summaries with a LOCAL LLM.
+#
+# Mycelium's built-in `maintain` pass is heuristic (decay + protected guard). This helper
+# adds an OPTIONAL, human-in-the-loop layer: it asks a *local* model to
+#   (A) group a batch of consolidation candidates into themes + dense cold summaries, and
+#   (B) PROPOSE which originals are safe to archive — which YOU verify before `forget`.
+#
+# The model DRAFTS; a human (or the forget-safety guard) DISPOSES. Never pipe this output
+# straight into deletion — small local models over-archive. See docs/local-llm-maintenance.md.
+#
+# Endpoint: any OpenAI-compatible /v1/chat/completions server (llama.cpp, vLLM, Ollama,
+# LM Studio). Configure via env:
+#   LOCAL_LLM_URL      default http://localhost:8080/v1/chat/completions
+#   LOCAL_LLM_MODEL    default "local"  (Ollama needs the real tag, e.g. "qwen3:8b")
+#   LOCAL_LLM_NOTHINK  set to 1 for reasoning models that hide output in reasoning_content
+#                      unless thinking is disabled (Qwen3-style)
+#
+# Usage:
+#   mycelium review                                    # find dense clusters
+#   mycelium consolidate --project infra > cands.txt   # dump candidates (id + text)
+#   ./scripts/consolidate-with-local-llm.sh < cands.txt
+#
+# Deps: curl, jq.
+set -euo pipefail
+
+URL="${LOCAL_LLM_URL:-http://localhost:8080/v1/chat/completions}"
+MODEL="${LOCAL_LLM_MODEL:-local}"
+
+read -r -d '' SYS <<'PROMPT' || true
+You consolidate an AI agent's long-term memory. Input: memory entries as [#ID] (date) content.
+
+Do TWO things:
+(A) Group entries into themes. Per theme output THEME / MEMBERS / SUMMARY — a dense cold
+    summary preserving EVERY ID, date, file path, and identifier, noting what supersedes what.
+(B) Recommend an archive/keep split — CONSERVATIVELY.
+
+ARCHIVING RULES (this is where local models overreach — do not):
+- DEFAULT IS KEEP. An entry is KEEP unless you can PROVE it is dead.
+- Mark ARCHIVE only if ONE holds, and cite the evidence inline:
+  1. SUPERSEDED — a newer entry (cite its #ID) fully captures this one.
+  2. HISTORICAL-EVENT — a one-time completed event whose durable state now lives elsewhere (say where).
+  3. DEAD — describes decommissioned/removed infrastructure (name what is dead).
+- NEVER archive: live config, credentials/access, standing conventions or feedback,
+  index/hub entries, or anything with an unresolved TODO/blocker.
+- FORBIDDEN reasons: "likely", "probably", "may be", "no mention" — any absence-of-evidence
+  guess. Not seeing a thing mentioned is NOT proof it is dead; that is a KEEP.
+- If you cannot cite a reason, it is KEEP. It is NORMAL for most entries to be KEEP;
+  a pass that archives everything is WRONG.
+
+OUTPUT (plain text, no preamble):
+<themes as above>
+ARCHIVE: one line per id -> `#ID — SUPERSEDED by #X` | `#ID — HISTORICAL-EVENT: state in Y` | `#ID — DEAD: Z`
+KEEP: comma-separated `#ID (short reason)`
+Every input ID must appear exactly once across ARCHIVE + KEEP.
+PROMPT
+
+CANDS="$(cat)"
+[ -n "$CANDS" ] || { echo "no candidates on stdin" >&2; exit 1; }
+
+BODY=$(jq -n --arg m "$MODEL" --arg sys "$SYS" --arg user "$CANDS" \
+  '{model:$m, temperature:0.2, max_tokens:4096,
+    messages:[{role:"system",content:$sys},{role:"user",content:$user}]}')
+
+# Reasoning models often return empty content unless thinking is disabled. The exact knob
+# is model-specific; enable_thinking=false covers Qwen3 and similar via chat_template_kwargs.
+if [ "${LOCAL_LLM_NOTHINK:-0}" = "1" ]; then
+  BODY=$(printf '%s' "$BODY" | jq '. + {chat_template_kwargs:{enable_thinking:false}}')
+fi
+
+printf '%s' "$BODY" \
+  | curl -sS "$URL" -H 'Content-Type: application/json' -d @- \
+  | jq -r '.choices[0].message.content // .error.message // "no response from endpoint"'


### PR DESCRIPTION
Adds an optional, human-in-the-loop layer for memory consolidation: use any OpenAI-compatible **local** model (llama.cpp / Ollama / vLLM / LM Studio) to draft cluster summaries and an archive/keep proposal, which a human verifies before `forget()`.

**What's here**
- `scripts/consolidate-with-local-llm.sh` — dependency-light `curl`+`jq` helper; endpoint configured via `LOCAL_LLM_URL` / `LOCAL_LLM_MODEL` / `LOCAL_LLM_NOTHINK`.
- `docs/local-llm-maintenance.md` — the workflow, the hardened prompt that stops small models from over-archiving (default-KEEP, positive-evidence citations, no absence-of-evidence deletions), and the reasoning-model empty-`content` gotcha.

Pairs with the forget safety guard: the model **proposes**, a human or the guard **disposes** — output is never wired straight into deletion.