### PR TITLE
docs: link local-LLM maintenance guide from README nav table

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ In rough order of "what new users do next":
 | Have Claude follow consistent rituals | [docs/claude-md-primer.md](docs/claude-md-primer.md) — paste into your CLAUDE.md |
 | Bootstrap with existing material | [docs/seeding.md](docs/seeding.md) — paste-prompts for seeding from CLAUDE.md, project trees, notes, shell history |
 | Tune behavior or change paths | [docs/configuration.md](docs/configuration.md) |
+| Offload memory upkeep to a local model | [docs/local-llm-maintenance.md](docs/local-llm-maintenance.md) — draft consolidation summaries with a local LLM, human-verified before deletion |
 | Hook up Claude Desktop, Codex, or another MCP client | [Multi-client setup](#multi-client-and-other-mcp-clients), below |
 | Read the longer thinking behind this | [docs/research/](docs/research/) — paper-form notes on memory governance for long-running agent systems |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# mycelium docs
+
+Start with **concepts**, then reach for the rest as you need them.
+
+| Doc | What it's for |
+|---|---|
+| [concepts.md](concepts.md) | Read-once overview — what mycelium actually is and how the pieces (recall, connections, decay, consolidation) fit together. |
+| [claude-md-primer.md](claude-md-primer.md) | A snippet to paste into your own `CLAUDE.md` so Claude uses mycelium consistently (recall before asking, save what's worth keeping). |
+| [configuration.md](configuration.md) | The single TOML config file, its sections, and the `MYCELIUM_*` env overrides. Zero-config works; override only what you care about. |
+| [seeding.md](seeding.md) | Bootstrap a fresh (empty) install — paste-prompts for seeding from an existing `CLAUDE.md`, project trees, notes, or shell history. |
+| [local-llm-maintenance.md](local-llm-maintenance.md) | Offload memory upkeep to a local LLM: draft consolidation summaries + an archive/keep proposal, human-verified before deletion. |
+| [research/](research/) | Long-form notes on the ideas behind mycelium — memory governance for long-running agent systems. |
+
+New here? [concepts.md](concepts.md) → install (see the [top-level README](../README.md)) → [claude-md-primer.md](claude-md-primer.md).


### PR DESCRIPTION
Follow-up to #6. The local-LLM maintenance guide was only reachable by browsing `docs/`; this adds one row to the README's "what new users do next" table so it's discoverable next to the other guides. No renames, no new index file (the table is the index).