### PR TITLE
feat: recency surfacing (recent()/wake) + contradicts_prior salience

### DIFF
--- a/benchmarks/hub_vs_recency.py
+++ b/benchmarks/hub_vs_recency.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Hub-vs-recency divergence: does hub-ranked context() surface recent work?
+
+Two mechanisms, one claim: ranking memories by hub centrality
+(access_count x (degree+1)) is NOT a proxy for ranking by recency
+(max(created, last_accessed)). This is structural, not incidental —
+
+  A memory can only accumulate accesses and co-access connections AFTER it is
+  created, so the all-time top hubs are necessarily OLD, high-traffic nodes; a
+  just-created memory, however important, has not had time to become a hub. So
+  the top-K by centrality and the top-K by recency are near-disjoint — the
+  set context() would surface at startup structurally excludes recent work.
+
+This script quantifies that with NO private data required:
+
+  --synthetic  (default)  seeded synthetic graph -> identical numbers for every
+                          reader; reproduces the result + a sensitivity sweep.
+  --db PATH               measure it on YOUR OWN mycelium graph (read-only).
+
+Metrics (both modes):
+  * top-K overlap / Jaccard       -- THE ROBUST HEADLINE: how many of the K most
+    recent memories does context()'s top-K also surface (near 0 in practice).
+  * Spearman(hub_score, recency)  -- whole-graph rank correlation, reported as a
+    diagnostic. Its SIGN is dataset-dependent (a live graph where sessions bump
+    access+recency together can be positive) — which is exactly why you can't
+    substitute hub-rank for recency: even when the bulk correlates, the tails
+    (the top-K you actually surface) do not.
+
+Stdlib only. Read-only (never writes to a real DB).
+"""
+import argparse
+import math
+import os
+import random
+import sqlite3
+
+
+def _ranks(vals):
+    """Fractional ranks (ties share the average rank)."""
+    order = sorted(range(len(vals)), key=lambda i: vals[i])
+    ranks = [0.0] * len(vals)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and vals[order[j + 1]] == vals[order[i]]:
+            j += 1
+        avg = (i + j) / 2.0
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def _spearman(xs, ys):
+    rx, ry = _ranks(xs), _ranks(ys)
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    mx, my = sum(rx) / n, sum(ry) / n
+    cov = sum((rx[i] - mx) * (ry[i] - my) for i in range(n))
+    vx = math.sqrt(sum((rx[i] - mx) ** 2 for i in range(n)))
+    vy = math.sqrt(sum((ry[i] - my) ** 2 for i in range(n)))
+    return cov / (vx * vy) if vx and vy else 0.0
+
+
+def measure(rows, k=15):
+    """rows: list of (hub_score, recency_key). recency_key: larger = more recent."""
+    hub = [r[0] for r in rows]
+    rec = [r[1] for r in rows]
+    idx = list(range(len(rows)))
+    top_hub = set(sorted(idx, key=lambda i: hub[i], reverse=True)[:k])
+    top_rec = set(sorted(idx, key=lambda i: rec[i], reverse=True)[:k])
+    inter = top_hub & top_rec
+    union = top_hub | top_rec
+    return {
+        "n": len(rows),
+        "spearman": _spearman(hub, rec),
+        "overlap": len(inter),
+        "k": min(k, len(rows)),
+        "jaccard": len(inter) / len(union) if union else 0.0,
+    }
+
+
+def build_synthetic(n, seed, days=180):
+    """A store simulated over `days`. Cumulative access & degree accumulate with
+    age (older memories have had more time + more co-access). A fraction are
+    'revisited' recently, which — realistically — bumps BOTH their recency AND
+    their access (a recall touches both), so recent work co-moves with access
+    just like a live graph. Nothing is tuned to force the result: the top hubs
+    are still the oldest highest-traffic nodes, and the newest memories haven't
+    had time to accumulate centrality — so the top-K sets separate regardless of
+    the (dataset-dependent) sign of the whole-graph correlation."""
+    rng = random.Random(seed)
+    rows = []
+    for _ in range(n):
+        age = rng.uniform(0, days)                          # days since created
+        cum = max(0.0, rng.gauss(age * 0.5, age * 0.2 + 1)) # accumulates with age
+        revisit = rng.random() < 0.15                       # 15% touched recently
+        if revisit:
+            recency_age = rng.uniform(0, 7)
+            cum += rng.uniform(3, 12)                        # recent burst bumps access too
+        else:
+            recency_age = age
+        access = int(cum)
+        degree = max(0, int(access * rng.uniform(0.3, 0.7)))  # co-access wiring
+        hub_score = access * (degree + 1)
+        rows.append((hub_score, -recency_age))              # -age: larger = more recent
+    return rows
+
+
+def load_db(db_path, k=15):
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    rs = conn.execute("""
+        SELECT m.id, (m.access_count * (COUNT(c.target) + 1)) AS hub_score,
+               max(m.created, m.last_accessed) AS recency
+        FROM memories m LEFT JOIN connections c ON m.id = c.source
+        GROUP BY m.id
+    """).fetchall()
+    conn.close()
+    # recency is an ISO string; rank lexically (UTC isoformat sorts chronologically)
+    return [(r["hub_score"], r["recency"]) for r in rs]
+
+
+def _report(title, m):
+    print(f"{title}")
+    print(f"  n = {m['n']}")
+    print(f"  top-{m['k']} overlap = {m['overlap']}/{m['k']}   Jaccard = {m['jaccard']:.3f}"
+          f"   <- robust headline: context()'s top-K ~excludes recent work")
+    print(f"  Spearman(hub, recency) = {m['spearman']:+.3f}"
+          f"   (diagnostic; sign is dataset-dependent)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--db", help="measure on a real mycelium DB (read-only)")
+    ap.add_argument("--synthetic", action="store_true", help="seeded synthetic graph (default)")
+    ap.add_argument("--n", type=int, default=2000)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--k", type=int, default=15)
+    args = ap.parse_args()
+
+    # --db wins. Otherwise, if not forced synthetic and the configured store
+    # actually exists (env override, else the default single-user path), measure
+    # it; a fresh clone with no store falls through to reproducible synthetic.
+    default_db = os.path.expanduser(
+        os.environ.get("MYCELIUM_STORAGE_DB_PATH", "~/.mycelium/memory.db")
+    )
+    db = args.db
+    if db is None and not args.synthetic and os.path.exists(default_db):
+        db = default_db
+    if db:
+        _report(f"=== Real graph: {db} ===", measure(load_db(db, args.k), args.k))
+        return
+
+    print(f"=== Synthetic graph (seed={args.seed}, accumulation-with-age model) ===")
+    _report(f"n={args.n}:", measure(build_synthetic(args.n, args.seed), args.k))
+    print("\n--- sensitivity: top-K overlap stays low across sizes (not a small-sample artifact) ---")
+    for n in (200, 500, 2000, 5000):
+        m = measure(build_synthetic(n, args.seed), args.k)
+        print(f"  n={n:>4}:  top-{m['k']} overlap {m['overlap']}/{m['k']}"
+              f"   (Spearman {m['spearman']:+.3f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/config.example.toml
+++ b/config.example.toml
@@ -25,6 +25,17 @@ recall_propagate = 8           # max neighbors to propagate per recall hit
 consolidation_threshold = 10   # nudge to consolidate above this hot-memory count per project
 pinned_decay_floor = 0.5       # pinned memories' connections never decay below this
 
+# Recency surfacing (recent() tool + GET /wake) — the episodic view context() is
+# blind to. recent() ranks by max(created, last_accessed), newest first.
+recent_window_days = 14        # episodic horizon for recent() / /wake
+recent_limit = 15              # max memories in a digest (mirrors hub_limit)
+recent_summary_chars = 140     # per-line content trim in the recent() text digest
+wake_summary_chars = 200       # per-item content trim in the /wake JSON payload
+# Prior-override salience: a memory saved with contradicts_prior=True gets this
+# ranking bump so a stored fact outranks the model's (possibly stale) training
+# prior. Kept > pinned's implicit weight so a learned exception wins.
+contradicts_prior_boost = 0.25
+
 # Optional: keyword clusters for the discover() pass.
 # Memories sharing any of these keywords get auto-linked. Add your own
 # domain terms (vendor names, project codenames, etc.) — leave empty to skip

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Start with **concepts**, then reach for the rest as you need them.
 | [concepts.md](concepts.md) | Read-once overview — what mycelium actually is and how the pieces (recall, connections, decay, consolidation) fit together. |
 | [claude-md-primer.md](claude-md-primer.md) | A snippet to paste into your own `CLAUDE.md` so Claude uses mycelium consistently (recall before asking, save what's worth keeping). |
 | [configuration.md](configuration.md) | The single TOML config file, its sections, and the `MYCELIUM_*` env overrides. Zero-config works; override only what you care about. |
+| [recency-precision.md](recency-precision.md) | The `recent()` / `/wake` episodic view (what context() is blind to) and the `contradicts_prior` salience flag that lets a stored fact outrank the model's training prior. |
 | [seeding.md](seeding.md) | Bootstrap a fresh (empty) install — paste-prompts for seeding from an existing `CLAUDE.md`, project trees, notes, or shell history. |
 | [local-llm-maintenance.md](local-llm-maintenance.md) | Offload memory upkeep to a local LLM: draft consolidation summaries + an archive/keep proposal, human-verified before deletion. |
 | [research/](research/) | Long-form notes on the ideas behind mycelium — memory governance for long-running agent systems. |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -219,7 +219,8 @@ for "show me every time I made this kind of decision" analysis later.
 | Tool | Use it when |
 |---|---|
 | `context(project="")` | Start of a session — load the hub memories. |
-| `save(content, project=)` | You learned something worth keeping. Short, dense. |
+| `recent(days=14, project=)` | Start of a session, next to `context()` — the episodic view of what was worked on lately (read-only; ranked by recency, which `context()` is blind to). See [recency-precision.md](recency-precision.md). |
+| `save(content, project=)` | You learned something worth keeping. Short, dense. Add `contradicts_prior=True` when it conflicts with what a model thinks it knows. |
 | `recall(query, project=)` | You need to look something up. |
 | `connections(memory_id)` | You want to see the local neighborhood of a memory. |
 | `pin(memory_id)` | This memory is human-confirmed, protect it. |

--- a/docs/recency-precision.md
+++ b/docs/recency-precision.md
@@ -1,0 +1,138 @@
+# Recency surfacing + prior-override precision
+
+Two small, coupled additions that fix two failures a *fresh* session has: it
+doesn't know what was worked on recently, and it will confidently assert
+stale facts about your own stack. Both are opt-in-free — they ship on by
+default and cost nothing until used.
+
+## The two problems
+
+They share one root cause: the store had a durable, well-connected layer
+(`context()` + the connection graph) but **no fast, recency-indexed view**, and
+**no way for a stored fact to outrank the model's training prior**.
+
+1. **Session amnesia.** `context()` ranks hubs by centrality —
+   `access_count × (connections + 1)`. That is recency-*blind*: a project worked
+   hard for three days last week has low centrality, so a new session never sees
+   it and never knows to `recall()` it. (Structural, not incidental — see the
+   [benchmark](#benchmark-hubs-are-not-recency).)
+2. **Confident-wrong assertions.** Asked to stand up a self-hosted service, a
+   fresh session says the free edition "was discontinued" — from stale training
+   data — when a memory records you actually running it. Retrieval isn't the
+   problem (the contradicting memory ranks fine); the session never *checks*,
+   because it thinks it already knows.
+
+## 1. `recent()` — the episodic view
+
+A new MCP tool `recent(days, limit, project)` plus a read-only `GET /wake` HTTP
+route. Both rank memories by `max(created, last_accessed)` — "written **or**
+recently active" — newest first, grouped by project.
+
+```
+recent()                     # last 14 days, all projects
+recent(days=3, project="x")  # tighter window, one project
+```
+
+Call it at the **start of a session, alongside `context()`**:
+
+> `context()` = what you durably know. `recent()` = what just happened.
+> Then `recall()` the specific threads you need.
+
+**It is read-only by construction.** `recent()` deliberately does **not** bump
+`last_accessed` or strengthen connections. Every normal `recall()` does — and if
+the startup digest *touched* what it surfaces, everything shown at session start
+would stay "recent" forever, a self-reinforcing loop. Surfacing is passive
+priming; only a real, model-initiated `recall()` earns reactivation.
+**Priming ≠ recall.** (A test fingerprints the table before/after to enforce it.)
+
+`GET /wake?days=14&limit=15&project=` returns the same digest as JSON for a
+`SessionStart` shell hook to `curl` — it never mutates state and degrades to
+`{"ok": false, "error": ...}` rather than a 500 that could read as "server down".
+
+## 2. `contradicts_prior` — prior-override salience
+
+A memory can now be saved with a flag that says *this conflicts with what a model
+thinks it knows*:
+
+```python
+# base knowledge says this edition is EOL — but you actually run it
+save("We run the community edition of $TOOL; vendor still ships 2026 releases",
+     contradicts_prior=True)
+```
+
+Mechanically it's an additive `INTEGER DEFAULT 0` column (migrated in place on
+existing DBs). When set, the memory gets a ranking bump (`contradicts_prior_boost`)
+in recall scoring and renders an **`[OVERRIDES-PRIOR]`** marker, so a stored truth
+outranks generic matches *and* signals the model to trust it over its prior. Set
+it at `save()` time, at the "huh, that still exists?" moment.
+
+Reach for it on the memories most likely to be steamrolled by a prior later: an
+edition/version base knowledge thinks is gone, a service on a nonstandard port, a
+tool used against its documented purpose.
+
+## Tunables
+
+All live in the `[memory]` config section (override via TOML or `MYCELIUM_*` env
+— see [configuration.md](configuration.md)):
+
+| Knob | Default | Meaning |
+|---|---|---|
+| `recent_window_days` | 14 | episodic horizon for `recent()` / `/wake` |
+| `recent_limit` | 15 | max memories in a digest (mirrors `hub_limit`) |
+| `recent_summary_chars` | 140 | per-line trim in the `recent()` text digest |
+| `wake_summary_chars` | 200 | per-item trim in the `/wake` JSON |
+| `contradicts_prior_boost` | 0.25 | salience bump; kept `>` pinned's weight so a learned exception beats a confident default |
+
+## Benchmark: hubs are not recency
+
+`benchmarks/hub_vs_recency.py` — stdlib-only, **reproducible** (`--synthetic`,
+fixed seed → identical numbers for everyone) and **self-serve** (`--db PATH`, or
+it auto-detects your configured store, read-only):
+
+```bash
+python benchmarks/hub_vs_recency.py              # seeded synthetic (default)
+python benchmarks/hub_vs_recency.py --db ~/.mycelium/memory.db   # your own graph
+```
+
+**Why it holds on any graph:** a memory only accumulates access and connections
+*after* it's created, so the all-time top hubs are necessarily old, high-traffic
+nodes — a just-created memory can't be a hub yet. So `context()`'s top-K and the
+top-K by recency are near-disjoint.
+
+Synthetic graph (seed 42):
+
+```
+top-15 overlap        = 0/15   Jaccard 0.000   <- context()'s top-K excludes recent work
+Spearman(hub,recency) = -0.52                  (diagnostic; SIGN is dataset-dependent)
+sensitivity n=200..5000: overlap 1/1/0/0       (stable, not a small-sample artifact)
+```
+
+**Overlap is the robust signal** — ~0 on the synthetic graph and on real graphs.
+The correlation *sign* is not: on a live graph, active sessions bump access and
+recency together, so the bulk can correlate *positively* — yet the top-K you'd
+actually surface stay disjoint. That's exactly why hub-rank can't stand in for
+recency, and why `recent()` is a **separate route** rather than a recency term
+folded into `context()` (which would need a magic weight and would regress the
+stable hub view).
+
+## Biomimetic framing — *inspired-by, not literal*
+
+The design mines memory neuroscience but doesn't claim to be a biological model.
+The honest ledger:
+
+| Design element | Inspiration | Status |
+|---|---|---|
+| fast episodic (`recent`) + slow consolidated (graph) | Complementary Learning Systems — McClelland/O'Reilly 1995; Kumaran et al. 2016 | **well-grounded** |
+| surfacing is a *view*, never drains the graph | consolidation is copy-and-extract, not move-and-delete (Multiple Trace / Trace Transformation — Nadel & Moscovitch) | grounded; enforced as the no-mutate rule |
+| recency raises retrieval score | ACT-R base-level activation — Anderson & Schooler 1991 | grounded math; *not* "neurons firing" |
+| `contradicts_prior` bumps conflicting facts | precision-weighting (Rao & Ballard; Friston) + behavioral tagging (Moncada & Viola) | **analogy/extension**, cited as such — not one proven mechanism |
+| forgetting = scroll-off + decay, not deletion | prioritized replay is real; "unreplayed decays" is inferred | engineering choice inspired by replay selectivity |
+
+## Wiring it up (harness side)
+
+`recent()` / `/wake` are meant to fire at session start — a `SessionStart` hook
+that `curl`s `/wake`, or a directive to run `context()` + `recent()` together. The
+prior-override discipline pairs with a client-side rule worth putting in your
+`CLAUDE.md` (see [claude-md-primer.md](claude-md-primer.md)): *never assert a
+world-fact about your own stack from base knowledge — recall first; a stored fact
+overrides the prior.*

--- a/mycelium/config.py
+++ b/mycelium/config.py
@@ -34,6 +34,15 @@ DEFAULTS: dict[str, Any] = {
         "consolidation_threshold": 10,
         "pinned_decay_floor": 0.5,
         "keyword_clusters": [],
+        # --- recency surfacing (recent() / /wake) + prior-override salience ---
+        "recent_window_days": 14,        # episodic horizon for recent() / /wake
+        "recent_limit": 15,              # max memories in a digest (mirrors hub_limit)
+        "recent_summary_chars": 140,     # per-line trim in the recent() text digest
+        "wake_summary_chars": 200,       # per-item trim in the /wake JSON payload
+        "contradicts_prior_boost": 0.25, # ranking bump for a stored fact that
+                                         # conflicts with base knowledge; deliberately
+                                         # > pin (0.1) so a learned exception beats a
+                                         # confident-but-wrong default
     },
     "foundry": {
         "enabled": True,

--- a/mycelium/server.py
+++ b/mycelium/server.py
@@ -167,7 +167,8 @@ def _init_schema(conn: sqlite3.Connection) -> None:
             access_count INTEGER DEFAULT 0,
             pinned INTEGER DEFAULT 0,
             confidence REAL DEFAULT 0.3,
-            source_type TEXT DEFAULT 'agent_observation'
+            source_type TEXT DEFAULT 'agent_observation',
+            contradicts_prior INTEGER DEFAULT 0
         );
 
         CREATE TABLE IF NOT EXISTS connections (
@@ -260,6 +261,18 @@ def _init_schema(conn: sqlite3.Connection) -> None:
             updated   TEXT    NOT NULL
         );
     """)
+
+    # contradicts_prior salience flag — additive migration. Marks memories whose
+    # content conflicts with the model's base/training knowledge (an edition base
+    # knowledge thinks is EOL, a service on a nonstandard port, a tool used against
+    # its documented purpose) so retrieval can outrank the prior. try/except ALTER
+    # keeps pre-existing DBs forward-compatible; the CREATE TABLE above already
+    # carries the column on fresh installs.
+    try:
+        conn.execute("SELECT contradicts_prior FROM memories LIMIT 1")
+    except sqlite3.OperationalError:
+        conn.execute("ALTER TABLE memories ADD COLUMN contradicts_prior INTEGER DEFAULT 0")
+
     conn.commit()
 
 
@@ -455,7 +468,7 @@ def _get_neighbors(conn: sqlite3.Connection, memory_id: int, limit: int | None =
         limit = _cfg().memory["recall_propagate"]
     rows = conn.execute(
         """
-        SELECT m.id, m.content, m.project, m.tier, m.access_count,
+        SELECT m.id, m.content, m.project, m.tier, m.access_count, m.contradicts_prior,
                c.strength, c.last_activated, c.co_access_count
         FROM connections c
         JOIN memories m ON m.id = c.target
@@ -476,6 +489,7 @@ def _get_neighbors(conn: sqlite3.Connection, memory_id: int, limit: int | None =
                 "content": r["content"],
                 "project": r["project"],
                 "tier": r["tier"],
+                "contradicts_prior": r["contradicts_prior"],
                 "connection_strength": round(decayed, 3),
                 "co_access_count": r["co_access_count"],
             })
@@ -524,7 +538,7 @@ def _fts_search(conn: sqlite3.Connection, query: str, limit: int = 10) -> list[d
         rows = conn.execute(
             """
             SELECT m.id, m.content, m.project, m.tier, m.access_count,
-                   m.created, m.last_accessed
+                   m.created, m.last_accessed, m.contradicts_prior
             FROM memories_fts f
             JOIN memories m ON m.id = f.rowid
             WHERE memories_fts MATCH ?
@@ -543,7 +557,7 @@ def _fts_search(conn: sqlite3.Connection, query: str, limit: int = 10) -> list[d
         rows = conn.execute(
             f"""
             SELECT m.id, m.content, m.project, m.tier, m.access_count,
-                   m.created, m.last_accessed
+                   m.created, m.last_accessed, m.contradicts_prior
             FROM memories m
             WHERE {clauses}
             LIMIT ?
@@ -571,7 +585,13 @@ def _fts_search(conn: sqlite3.Connection, query: str, limit: int = 10) -> list[d
                 recency_boost = 0.3 * math.exp(-days_old / 3.0)
             except (ValueError, TypeError):
                 pass
-        return coverage + access_boost + recency_boost
+        # Salience: keep prior-contradicting facts in the candidate pool so the
+        # top-`limit` cut here doesn't drop them before recall() re-ranks.
+        salience_boost = (
+            _cfg().memory["contradicts_prior_boost"]
+            if memory.get("contradicts_prior") else 0.0
+        )
+        return coverage + access_boost + recency_boost + salience_boost
 
     results.sort(key=_score, reverse=True)
     return results[:limit]
@@ -585,6 +605,8 @@ def _format_memory(m: dict) -> str:
         parts.append("[consolidated]")
     if m.get("pinned"):
         parts.append("[pinned]")
+    if m.get("contradicts_prior"):
+        parts.append("[OVERRIDES-PRIOR]")
     parts.append(m["content"])
     if m.get("connection_strength"):
         parts.append(f"[strength: {m['connection_strength']}]")
@@ -637,7 +659,7 @@ def _check_duplicates(conn, content: str, project: str = "", threshold: float = 
     candidates = _fts_search(conn, content, limit=8)
     if project:
         proj_memories = conn.execute(
-            "SELECT id, content, project, tier, access_count, created, last_accessed "
+            "SELECT id, content, project, tier, access_count, created, last_accessed, contradicts_prior "
             "FROM memories WHERE project = ? ORDER BY last_accessed DESC LIMIT 20",
             (project,),
         ).fetchall()
@@ -674,12 +696,20 @@ def save(
     pinned: bool = False,
     confidence: float = 0.3,
     source_type: str = "agent_observation",
+    contradicts_prior: bool = False,
 ) -> str:
     """Save a memory. Keep it short and dense — one idea per memory.
 
     The system auto-connects it to similar existing memories. If a similar memory
     already exists, suggests updating instead — pass force=True to save anyway.
     Set pinned=True for human-confirmed facts; pinned memories resist decay.
+
+    Set contradicts_prior=True when the fact conflicts with your base/training
+    knowledge — e.g. the user runs an edition/version base knowledge thinks is
+    gone, a service on a nonstandard port, a tool used against its documented
+    purpose. These are the memories most likely to be steamrolled by your prior
+    later; the flag makes them outrank generic matches at recall time and renders
+    an [OVERRIDES-PRIOR] marker.
     """
     conn = get_db()
     now = _now()
@@ -704,8 +734,8 @@ def save(
 
     cur = conn.execute(
         "INSERT INTO memories (content, project, tier, created, last_accessed, "
-        "access_count, pinned, confidence, source_type) "
-        "VALUES (?,?,'hot',?,?,1,?,?,?)",
+        "access_count, pinned, confidence, source_type, contradicts_prior) "
+        "VALUES (?,?,'hot',?,?,1,?,?,?,?)",
         (
             content,
             project,
@@ -714,6 +744,7 @@ def save(
             1 if pinned else 0,
             0.8 if pinned else confidence,
             source_type,
+            1 if contradicts_prior else 0,
         ),
     )
     new_id = cur.lastrowid
@@ -840,7 +871,7 @@ def recall(query: str, project: str = "", limit: int = 5, agent: str = "") -> st
 
     if not results and project:
         results = conn.execute(
-            "SELECT id, content, project, tier, access_count, created, last_accessed "
+            "SELECT id, content, project, tier, access_count, created, last_accessed, contradicts_prior "
             "FROM memories WHERE project=? ORDER BY last_accessed DESC LIMIT ?",
             (project, limit),
         ).fetchall()
@@ -867,7 +898,7 @@ def recall(query: str, project: str = "", limit: int = 5, agent: str = "") -> st
             if mid in have:
                 continue
             row = conn.execute(
-                "SELECT id, content, project, tier, access_count, created, last_accessed "
+                "SELECT id, content, project, tier, access_count, created, last_accessed, contradicts_prior "
                 "FROM memories WHERE id=?",
                 (mid,),
             ).fetchone()
@@ -910,7 +941,13 @@ def recall(query: str, project: str = "", limit: int = 5, agent: str = "") -> st
         # Semantic similarity as a primary ranking signal (semantic-led). 0 when
         # disabled or the memory has no vector, so lexical behavior is unchanged.
         semantic_boost = float(sem["weight"]) * sims.get(memory["id"], 0.0) if sims else 0.0
-        return coverage + access_boost + recency_boost + semantic_boost
+        # Salience: a fact flagged as contradicting base/training knowledge must
+        # outrank generic matches so a stored truth beats the model's prior.
+        salience_boost = (
+            _cfg().memory["contradicts_prior_boost"]
+            if memory.get("contradicts_prior") else 0.0
+        )
+        return coverage + access_boost + recency_boost + semantic_boost + salience_boost
 
     pool: dict[int, tuple[dict, float, str]] = {}
     for r in results:
@@ -1056,6 +1093,172 @@ def context(project: str = "", agent: str = "") -> str:
 
     conn.close()
     return "\n".join(lines)
+
+
+# ============================================================================
+# Recency surfacing — recent() episodic digest + GET /wake
+# ----------------------------------------------------------------------------
+# CLS-inspired (McClelland/O'Reilly 1995): context() above is the neocortical
+# hub route — it ranks by access × connections and is recency-BLIND. recent() is
+# the hippocampal episodic route — it ranks purely by recency so a fresh session
+# sees what was *just* worked on, which hub-centrality structurally drowns (a new
+# memory hasn't had time to become a hub). This is a READ-ONLY view over existing
+# rows — consolidation is copy-not-move, so surfacing empties nothing.
+#
+# CRITICAL — surfacing must not reactivate: recent()/_recent_rows deliberately
+# skip _touch_memory + _track_session_access. Every normal recall() bumps
+# last_accessed; if the wake digest touched what it surfaces, everything shown at
+# session start would stay "recent" forever (a self-reinforcing loop). Only a
+# real, model-initiated recall() earns the Hebbian reactivation. Priming ≠ recall.
+# ============================================================================
+
+def _column_exists(conn: sqlite3.Connection, table: str, col: str) -> bool:
+    """True if `col` exists on `table`. Lets recent() run on schemas both before
+    and after the contradicts_prior migration (forward-compatible)."""
+    try:
+        conn.execute(f"SELECT {col} FROM {table} LIMIT 1")
+        return True
+    except sqlite3.OperationalError:
+        return False
+
+
+def _humanize_age(iso: str) -> str:
+    """Compact age like '9m' / '3h' / '5d' from an ISO timestamp."""
+    try:
+        dt = datetime.fromisoformat(iso)
+    except (ValueError, TypeError):
+        return "?"
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    secs = max(0.0, (datetime.now(timezone.utc) - dt).total_seconds())
+    if secs < 3600:
+        return f"{int(secs // 60)}m"
+    if secs < 86400:
+        return f"{int(secs // 3600)}h"
+    return f"{int(secs // 86400)}d"
+
+
+def _recent_rows(conn: sqlite3.Connection, days: int, limit: int,
+                 project: str = "") -> list[dict]:
+    """Recency-ranked memories (episodic view), newest first. READ-ONLY: no
+    _touch_memory / no co-access strengthening (see section header). Recency =
+    max(created, last_accessed) — a memory counts as recent if it was written OR
+    genuinely recalled lately. Timestamps are UTC isoformat → lexical compare
+    matches chronological order. `contradicts_prior` is selected when present so
+    the digest can flag prior-overriding facts; degrades to 0 on older schemas."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=max(0, days))).isoformat()
+    cp_sel = "contradicts_prior" if _column_exists(conn, "memories", "contradicts_prior") else "0 AS contradicts_prior"
+    params: list = [cutoff]
+    proj_clause = ""
+    if project:
+        proj_clause = "AND project = ?"
+        params.append(project)
+    params.append(max(1, limit))
+    rows = conn.execute(f"""
+        SELECT id, content, project, tier, created, last_accessed,
+               access_count, pinned, confidence, {cp_sel},
+               max(created, last_accessed) AS recency
+        FROM memories
+        WHERE max(created, last_accessed) >= ? {proj_clause}
+        ORDER BY recency DESC
+        LIMIT ?
+    """, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _recent_summary_line(m: dict, trim: int) -> str:
+    """One dense line for the digest: id, age, markers, trimmed content."""
+    markers = []
+    if m.get("pinned"):
+        markers.append("[pinned]")
+    if m.get("contradicts_prior"):
+        markers.append("[OVERRIDES-PRIOR]")
+    if m.get("tier") == "cold":
+        markers.append("[consolidated]")
+    mk = (" ".join(markers) + " ") if markers else ""
+    age = _humanize_age(m.get("recency") or m.get("last_accessed") or m.get("created") or "")
+    body = " ".join((m.get("content") or "").split())
+    if len(body) > trim:
+        body = body[:trim - 1].rstrip() + "…"
+    return f"[#{m['id']}] {age} · {mk}{body}"
+
+
+@mcp.tool()
+@resilient
+def recent(days: int | None = None, limit: int | None = None, project: str = "") -> str:
+    """Recent episodic digest — what's been worked on lately, newest first.
+
+    Ranks by recency (max of created / last-accessed) — the axis context() is
+    blind to (context() ranks hubs by access × connections). Call at the START of
+    a session alongside context(): context() = what you durably know, recent() =
+    what just happened. Then recall() the specific threads you need.
+
+    READ-ONLY: this does NOT touch or strengthen memories, so priming on recent
+    work doesn't make that work look permanently recent. [OVERRIDES-PRIOR]
+    markers flag facts about the user's stack that contradict base knowledge —
+    trust them over your training prior.
+    """
+    mem = _cfg().memory
+    days = mem["recent_window_days"] if days is None else days
+    limit = mem["recent_limit"] if limit is None else limit
+    trim = mem["recent_summary_chars"]
+    conn = get_db()
+    rows = _recent_rows(conn, days=days, limit=limit, project=project)
+    conn.close()
+    if not rows:
+        return f"No memory activity in the last {days} days."
+
+    # Group by project; projects ordered by their most-recent item (rows already
+    # newest-first, so first occurrence wins), memories newest-first within.
+    order: list[str] = []
+    groups: dict[str, list[dict]] = {}
+    for m in rows:
+        key = m.get("project") or "(no project)"
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(m)
+
+    lines = [f"## Recent activity — last {days}d, {len(rows)} memories (newest first)"]
+    for key in order:
+        lines.append(f"\n### {key}")
+        for m in groups[key]:
+            lines.append(f"  {_recent_summary_line(m, trim)}")
+    return "\n".join(lines)
+
+
+@mcp.custom_route("/wake", methods=["GET"])
+async def wake_route(request):
+    """Read-only recency digest for a SessionStart shell hook to curl.
+    GET /wake?days=14&limit=15&project= → JSON. Never mutates state; degrades to
+    an error object rather than a 500 that could read as 'server down'."""
+    from starlette.responses import JSONResponse
+    mem = _cfg().memory
+    try:
+        days = int(request.query_params.get("days", mem["recent_window_days"]))
+        limit = int(request.query_params.get("limit", mem["recent_limit"]))
+        project = request.query_params.get("project", "")
+    except (ValueError, TypeError):
+        days, limit, project = mem["recent_window_days"], mem["recent_limit"], ""
+    trim = mem["wake_summary_chars"]
+    conn = get_db()
+    try:
+        rows = _recent_rows(conn, days=days, limit=limit, project=project)
+    except Exception as e:  # never crash the hook's request
+        conn.close()
+        return JSONResponse({"ok": False, "error": str(e), "recent": []})
+    conn.close()
+    items = [{
+        "id": m["id"],
+        "project": m.get("project") or "",
+        "age": _humanize_age(m.get("recency") or m.get("last_accessed") or m.get("created") or ""),
+        "pinned": bool(m.get("pinned")),
+        "overrides_prior": bool(m.get("contradicts_prior")),
+        "tier": m.get("tier") or "hot",
+        "summary": " ".join((m.get("content") or "").split())[:trim],
+    } for m in rows]
+    return JSONResponse({"ok": True, "generated": _now(), "days": days,
+                         "count": len(items), "recent": items})
 
 
 @mcp.tool()

--- a/tests/test_recency_precision.py
+++ b/tests/test_recency_precision.py
@@ -1,0 +1,155 @@
+"""Recency surfacing (recent() / /wake) + contradicts_prior salience.
+
+Runs against throwaway temp DBs (tmp_path + MYCELIUM_STORAGE_DB_PATH) so recency
+boundaries, the max(created, last_accessed) rule, the READ-ONLY invariant, and the
+salience ranking are all checked deterministically — no network, no prod data.
+
+Covers:
+  - contradicts_prior migration lands the column on a fresh schema
+  - recent()/_recent_rows is READ-ONLY (surfacing never mutates the graph)
+  - recency window = max(created, last_accessed): an old-but-recently-recalled
+    memory surfaces; a stale one is excluded; results are newest-first
+  - save(contradicts_prior=True) persists the flag; a generic save leaves it 0
+  - a flagged memory OUTRANKS a generic one with equal keyword coverage
+  - [OVERRIDES-PRIOR] renders in recall() and the flag rides through recent()
+"""
+import hashlib
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from mycelium import config as _config
+from mycelium import server as S
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_state():
+    # server tracks co-accessed memories in a process-wide contextvar; these
+    # tests swap DBs in-process, so reset between tests to avoid ID bridging.
+    S._session_accessed.set(None)
+    yield
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    """Point the server at a fresh temp DB (created with the current schema)."""
+    monkeypatch.setenv("MYCELIUM_STORAGE_DB_PATH", str(tmp_path / "m.db"))
+    monkeypatch.delenv("MYCELIUM_SEMANTIC_EMBED_URL", raising=False)
+    S.set_config(_config.load())
+    return str(tmp_path / "m.db")
+
+
+def _iso(days_ago=0, hours_ago=0):
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago, hours=hours_ago)).isoformat()
+
+
+# fixtures: (content, project, created_days_ago, last_accessed_days_ago, pinned, tier)
+_FIX = [
+    ("Fresh checkpoint today",          "proj-alpha",  0,  0, 0, "hot"),
+    ("Old note but RECALLED yesterday", "proj-beta",  40,  1, 0, "hot"),
+    ("Beta pinned fact 5d",             "proj-beta",   5,  5, 1, "hot"),
+    ("Consolidated cold index 8d",      "proj-beta",   8,  8, 0, "cold"),
+    ("Stale 20d excluded at 14d",       "proj-gamma", 20, 20, 0, "hot"),
+]
+
+
+def _seed(db_path):
+    conn = S.get_db()  # creates the modern schema incl. contradicts_prior
+    for content, proj, cda, lda, pin, tier in _FIX:
+        conn.execute(
+            "INSERT INTO memories (content, project, tier, created, last_accessed, "
+            "access_count, pinned, confidence) VALUES (?,?,?,?,?,3,?,0.3)",
+            (content, proj, tier, _iso(cda), _iso(lda), pin),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _fingerprint():
+    # Read through get_db() (same WAL connection the app uses) so we observe
+    # committed state; a foreign sqlite3.connect() can miss uncheckpointed WAL.
+    # get_db() re-runs CREATE IF NOT EXISTS but never touches last_accessed /
+    # access_count, so it's a faithful, side-effect-free snapshot of the invariant.
+    conn = S.get_db()
+    rows = conn.execute(
+        "SELECT id, last_accessed, access_count FROM memories ORDER BY id"
+    ).fetchall()
+    conn.close()
+    h = hashlib.sha256()
+    for r in rows:
+        h.update(f"{r['id']}|{r['last_accessed']}|{r['access_count']};".encode())
+    return h.hexdigest()
+
+
+def test_migration_adds_contradicts_prior_column(db):
+    conn = S.get_db()
+    try:
+        assert S._column_exists(conn, "memories", "contradicts_prior")
+    finally:
+        conn.close()
+
+
+def test_recent_is_read_only(db):
+    _seed(db)
+    before = _fingerprint()
+    conn = S.get_db()
+    S._recent_rows(conn, days=14, limit=15)
+    conn.close()
+    assert _fingerprint() == before
+
+
+def test_recency_window_and_ordering(db):
+    _seed(db)
+    conn = S.get_db()
+    rows = S._recent_rows(conn, days=14, limit=15)
+    conn.close()
+    contents = [r["content"] for r in rows]
+    # 20d-stale falls outside the 14d window
+    assert "Stale 20d excluded at 14d" not in contents
+    # max(created, last_accessed): old memory recalled yesterday still surfaces
+    assert "Old note but RECALLED yesterday" in contents
+    # newest-first
+    recencies = [r["recency"] for r in rows]
+    assert recencies == sorted(recencies, reverse=True)
+
+
+def test_salience_boost_config_value(db):
+    # The boost is a real, positive knob and (per design) exceeds pinned's 0.1.
+    boost = S._cfg().memory["contradicts_prior_boost"]
+    assert boost == pytest.approx(0.25)
+    assert boost > 0.1
+
+
+def _saved_id(msg):
+    return int(msg.split("#", 1)[1].split()[0].strip("( )"))
+
+
+def test_flag_persists_and_outranks_generic(db):
+    gen = S.save("Zorbex platform general onboarding notes and setup", project="zx", force=True)
+    flg = S.save("Zorbex platform Team Edition is still actively shipped 2026",
+                 project="zx", contradicts_prior=True, force=True)
+    id_gen, id_flg = _saved_id(gen), _saved_id(flg)
+
+    conn = S.get_db()
+    f_flag = conn.execute("SELECT contradicts_prior FROM memories WHERE id=?", (id_flg,)).fetchone()[0]
+    g_flag = conn.execute("SELECT contradicts_prior FROM memories WHERE id=?", (id_gen,)).fetchone()[0]
+    conn.close()
+    assert f_flag == 1
+    assert g_flag == 0
+
+    out = S.recall("Zorbex platform", limit=5)
+    pos_flg, pos_gen = out.find(f"#{id_flg}"), out.find(f"#{id_gen}")
+    assert pos_flg >= 0 and pos_gen >= 0, out
+    # equal keyword coverage → the salience bump decides: flagged ranks first
+    assert pos_flg < pos_gen, out
+    assert "[OVERRIDES-PRIOR]" in out
+
+
+def test_recent_carries_flag(db):
+    flg = S.save("Widget daemon runs on port 9999 not the documented 8080",
+                 project="zx", contradicts_prior=True, force=True)
+    id_flg = _saved_id(flg)
+    conn = S.get_db()
+    rows = S._recent_rows(conn, days=1, limit=20)
+    conn.close()
+    assert any(r["id"] == id_flg and r["contradicts_prior"] == 1 for r in rows)


### PR DESCRIPTION
Two coupled additions that make a *fresh* session aware of recent work and stop it asserting confidently-wrong facts about the user's own stack.

## 1. `recent()` + `GET /wake` — the episodic view
`context()` ranks hubs by `access_count × (connections+1)` and is **recency-blind** — a project worked hard last week has low centrality, so a new session never sees it. `recent(days, limit, project)` ranks by `max(created, last_accessed)`, newest-first, grouped by project. `GET /wake` returns the same digest as JSON for a `SessionStart` hook to `curl`.

**Read-only by construction:** `recent()`/`_recent_rows` deliberately skip `_touch_memory`/`_track_session_access`. Every normal `recall()` bumps `last_accessed`; if the wake digest touched what it surfaces, everything shown at session start would stay "recent" forever. Priming ≠ recall. A test fingerprints the table before/after to enforce it.

## 2. `contradicts_prior` — prior-override salience
An additive `INTEGER DEFAULT 0` column (migrated in place). `save(..., contradicts_prior=True)` flags a fact that conflicts with a model's training prior (an edition base knowledge thinks is EOL, a service on a nonstandard port). It gets a `contradicts_prior_boost` (0.25, `>` pin) in **both** recall scoring paths and renders an `[OVERRIDES-PRIOR]` marker, so the stored fact outranks generic matches.

## Tunables
All in the `[memory]` config section: `recent_window_days`, `recent_limit`, `recent_summary_chars`, `wake_summary_chars`, `contradicts_prior_boost`.

## Why a separate route (benchmark)
`benchmarks/hub_vs_recency.py` (stdlib-only, reproducible `--synthetic` + self-serve `--db`) shows hub-rank and recency top-K are near-disjoint: seeded synthetic → **top-15 overlap 0/15**. A memory only accrues access/connections *after* creation, so top hubs are structurally old; folding recency into `context()` would need a magic weight and regress the stable hub view.

## Docs & tests
- `docs/recency-precision.md` — design, tunables, and an honest biomimetic-inspiration ledger (CLS / ACT-R / predictive-coding, cited as analogy where it is one).
- `tests/test_recency_precision.py` — window rule, newest-first ordering, read-only invariant, migration, flag persistence, flagged-outranks-generic on equal coverage. Full suite **16/16** on Python 3.11.