### PR TITLE
docs(readme): surface the recency view in "What it does"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Things you reference stay strong. Things you ignore fade. Similar ideas link
 themselves through use. The shape of your knowledge emerges from how you
-actually work — you don't curate folders or maintain an index.
+actually work. You don't curate folders or maintain an index.
 
 Single-process MCP server, SQLite + FTS5, zero external services. Works with
 Claude Code, Claude Desktop, Codex CLI, or any MCP-speaking client. They can
@@ -30,12 +30,12 @@ all share the same memory store.
 
 Two memory systems in one install:
 
-- **Semantic memory** — the durable "what I know" store. Save observations,
+- **Semantic memory**: the durable "what I know" store. Save observations,
   decisions, project facts, conventions. Recall them later by natural-language
   query. Connections form automatically through co-access; unused paths decay.
   Recall is keyword-based out of the box; optionally enable
   [semantic recall](#optional-semantic-recall) to also match by *meaning*.
-- **Behavioral memory (foundry)** — append-only log of decisions. "Picked the
+- **Behavioral memory (foundry)**: append-only log of decisions. "Picked the
   cheaper model tier for this prompt size." Queryable later for pattern
   analysis or training-data extraction. Optional; turn off if unused.
 
@@ -50,16 +50,16 @@ outrank whatever the model picked up in training. Details in
 
 Plus two slash-skill conventions and a short-term memory hook for Claude Code:
 
-- **`/checkpoint`** — save the current session's state to memory before
+- **`/checkpoint`**: save the current session's state to memory before
   `/clear`. Resume next time exactly where you left off.
-- **`/maintain`** — periodic janitor pass (snapshot, cold-mark duplicates,
+- **`/maintain`**: periodic janitor pass (snapshot, cold-mark duplicates,
   rescue orphans) with safety guards. Dry-run by default; asks before applying.
-- **STM hook** — a 6-entry buffer of operational lessons that get injected
+- **STM hook**: a 6-entry buffer of operational lessons that get injected
   *before* matching tool runs, so Claude sees the workaround before hitting
   the same wall again.
 
 > **Want the full mental model before installing?** Read
-> [docs/concepts.md](docs/concepts.md) — what each tool is *for* in plain
+> [docs/concepts.md](docs/concepts.md): what each tool is *for* in plain
 > language, what conventions like `[session-checkpoint]` mean, the
 > gardener-not-librarian framing. ~10 minutes, no commands.
 
@@ -74,17 +74,17 @@ If you'd rather read it as a transcript:
 
 ```
 You:    [start of a new session]
-Claude: [calls context() automatically — sees your project hubs]
+Claude: [calls context() automatically, sees your project hubs]
         "Looks like we're in the middle of acme-api. The OAuth refactor is at
          step 3 and you mentioned the staging migration is next."
 
 You:    "Right. Let's pick that up."
 Claude: [calls recall("staging migration acme-api")]
-        "OK — last session you confirmed the schema change goes in 0042 and
+        "OK, last session you confirmed the schema change goes in 0042 and
          we agreed to use a backfill column. Want me to start there?"
 
 You:    "Yes, and remember the column should default to FALSE not NULL."
-Claude: [calls save("acme-api migration columns default FALSE not NULL — was
+Claude: [calls save("acme-api migration columns default FALSE not NULL, was
          a source of bugs last quarter", project="acme-api", pinned=true)]
         "Saved and pinned."
 ```
@@ -98,7 +98,7 @@ in [docs/concepts.md](docs/concepts.md) are its mental model.
 ### Easiest: have Claude do it
 
 You already have Claude Code installed (it's how you'll use this). Paste this
-prompt into a Claude Code session — it detects your OS, picks the install
+prompt into a Claude Code session. It detects your OS, picks the install
 method, runs the smoke test, and wires up the MCP. Read the actions before
 approving.
 
@@ -113,18 +113,18 @@ Constraints:
   (or `py -m pip install --user ...` on Windows) if pipx is unavailable.
 - NEVER use sudo. NEVER use --break-system-packages without confirming with me.
 - Use `pip install git+https://github.com/constant-itis/mycelium-memory`
-  (or the pipx equivalent) — this isn't on PyPI yet.
+  (or the pipx equivalent). This isn't on PyPI yet.
 - After install, run the smoke test:
   curl -sL https://raw.githubusercontent.com/constant-itis/mycelium-memory/main/scripts/smoke-test.sh | bash
   (Use Git Bash / WSL on Windows.)
 - If the smoke test passes, register with Claude Code:
   claude mcp add mycelium -- mycelium serve
   Then verify with: claude mcp list
-- Optional follow-ups — ASK ME before doing any of these:
+- Optional follow-ups, ASK ME before doing any of these:
   1. Append the CLAUDE.md primer (docs/claude-md-primer.md) to my CLAUDE.md.
   2. Install the /checkpoint, /maintain, and /discover skills (clone the
      repo, symlink each skills/<name> dir into ~/.claude/skills/).
-  3. Install the STM hook (clone the repo, run hooks/stm/install.sh —
+  3. Install the STM hook (clone the repo, run hooks/stm/install.sh,
      requires jq).
 
 Report back: what got installed, where, and which optional steps you'd
@@ -162,18 +162,18 @@ In rough order of "what new users do next":
 | Want to... | Read |
 |---|---|
 | Understand the whole system | [docs/concepts.md](docs/concepts.md) |
-| Have Claude follow consistent rituals | [docs/claude-md-primer.md](docs/claude-md-primer.md) — paste into your CLAUDE.md |
-| Bootstrap with existing material | [docs/seeding.md](docs/seeding.md) — paste-prompts for seeding from CLAUDE.md, project trees, notes, shell history |
+| Have Claude follow consistent rituals | [docs/claude-md-primer.md](docs/claude-md-primer.md), paste into your CLAUDE.md |
+| Bootstrap with existing material | [docs/seeding.md](docs/seeding.md), paste-prompts for seeding from CLAUDE.md, project trees, notes, shell history |
 | Tune behavior or change paths | [docs/configuration.md](docs/configuration.md) |
-| Offload memory upkeep to a local model | [docs/local-llm-maintenance.md](docs/local-llm-maintenance.md) — draft consolidation summaries with a local LLM, human-verified before deletion |
+| Offload memory upkeep to a local model | [docs/local-llm-maintenance.md](docs/local-llm-maintenance.md), draft consolidation summaries with a local LLM, human-verified before deletion |
 | Hook up Claude Desktop, Codex, or another MCP client | [Multi-client setup](#multi-client-and-other-mcp-clients), below |
-| Read the longer thinking behind this | [docs/research/](docs/research/) — paper-form notes on memory governance for long-running agent systems |
+| Read the longer thinking behind this | [docs/research/](docs/research/), paper-form notes on memory governance for long-running agent systems |
 
 ## Multi-client and other MCP clients
 
 Mycelium is a vanilla MCP server. Anything that speaks MCP can connect.
 Lessons from your morning Claude session show up in your afternoon Codex
-session — same SQLite, same memories.
+session. Same SQLite, same memories.
 
 ### Claude Desktop App
 
@@ -207,10 +207,10 @@ mycelium serve --transport http --port 8200 &
 
 ### Multi-client mechanics
 
-- **Same machine, multiple stdio clients** — each spawns its own server
+- **Same machine, multiple stdio clients**: each spawns its own server
   process, both hit the same `~/.mycelium/memory.db`. SQLite WAL handles it.
   Just works.
-- **Multiple machines** — run one HTTP server, point each client at it.
+- **Multiple machines**: run one HTTP server, point each client at it.
 
 > **Security:** the MCP server has no auth. Bind HTTP transport to
 > `127.0.0.1` for one machine, or to a private interface (Tailscale, LAN)
@@ -218,13 +218,13 @@ mycelium serve --transport http --port 8200 &
 
 ## Optional: semantic recall
 
-By default, recall is lexical (SQLite FTS5) — fast, zero-dependency, and it
+By default, recall is lexical (SQLite FTS5): fast, zero-dependency, and it
 matches on keywords. If you also point mycelium at an embedding endpoint, recall
 becomes **hybrid**: it additionally finds memories by *meaning*, so a query like
 "how does the token refresh work" can surface a note about "OAuth credential
 renewal" even with no shared words.
 
-This is **off by default** and adds **no dependency** — set one config value to
+This is **off by default** and adds **no dependency**: set one config value to
 turn it on, leave it unset and nothing changes.
 
 ```toml
@@ -234,7 +234,7 @@ embed_url = "http://localhost:11434/v1/embeddings"   # any OpenAI-compatible end
 embed_model = "nomic-embed-text"
 ```
 
-Works with anything that speaks the OpenAI `/v1/embeddings` API — **Ollama**
+Works with anything that speaks the OpenAI `/v1/embeddings` API: **Ollama**
 (`ollama pull nomic-embed-text`), LM Studio, llama.cpp `--embedding`, or a cloud
 provider. Then embed your existing memories once:
 
@@ -242,7 +242,7 @@ provider. Then embed your existing memories once:
 mycelium backfill-vectors      # new memories are embedded automatically on save
 ```
 
-**Not sure it's worth it for your data?** Benchmark it — `mycelium eval` measures
+**Not sure it's worth it for your data?** Benchmark it. `mycelium eval` measures
 recall with semantic off vs on (bundled sample, or `--dataset yours.json`). See
 [docs/benchmarks.md](docs/benchmarks.md) for the decision guide and how to tune.
 
@@ -258,7 +258,7 @@ Notes:
 Your data lives in `~/.mycelium/memory.db` (semantic) and
 `~/.mycelium/foundry.db` + `~/.mycelium/foundry/logs/*.jsonl` (behavioral).
 Back them up like any other important file. The JSONL files are the durable
-source for foundry — if you lose `foundry.db`, re-ingest from JSONL with
+source for foundry. If you lose `foundry.db`, re-ingest from JSONL with
 `mycelium foundry ingest`.
 
 ## Troubleshooting
@@ -271,7 +271,7 @@ source for foundry — if you lose `foundry.db`, re-ingest from JSONL with
 | MCP doesn't appear in Claude | Restart Claude Code. `claude mcp list` confirms registration. Run `mycelium serve` directly to see startup errors. |
 | `database is locked` | Rare WAL contention. Retry. Check no zombie `mycelium serve` is still running. |
 | Config not behaving like the file says | `mycelium config` shows what's actually resolved + the source. Env vars override file values. |
-| `recall()` returns nothing for something I saved | Check the `project` field — recall is project-scoped when you pass `project=`. |
+| `recall()` returns nothing for something I saved | Check the `project` field. Recall is project-scoped when you pass `project=`. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Two memory systems in one install:
   cheaper model tier for this prompt size." Queryable later for pattern
   analysis or training-data extraction. Optional; turn off if unused.
 
+The semantic store also has a **recency view**. `context()` surfaces the hubs
+of your memory, the connected things you lean on most, but it can't see what you
+touched an hour ago. `recent()` (and the `/wake` startup view) covers that blind
+spot: a plain, time-ordered look at what just happened, so a fresh session
+resumes on the actual last thread instead of the all-time favorites. Stored
+facts can also carry a `contradicts_prior` flag, so something you saved can
+outrank whatever the model picked up in training. Details in
+[docs/recency-precision.md](docs/recency-precision.md).
+
 Plus two slash-skill conventions and a short-term memory hook for Claude Code:
 
 - **`/checkpoint`** — save the current session's state to memory before


### PR DESCRIPTION
The `recent()` / `/wake` episodic view and the `contradicts_prior` salience flag shipped with their own `docs/recency-precision.md`, but the top-level README never mentions them. Its "What it does" section only pitches semantic memory + foundry, so a new reader lands on the repo and never learns the recency view exists, even though it is one of the sharper differentiators (what `context()` is blind to).

This adds a short paragraph to that section pointing at the detail doc. Docs-only, no code change.